### PR TITLE
Use CPU affinity as CPU basis and report resources

### DIFF
--- a/src/hpc_scripts/psutil_monitor.py
+++ b/src/hpc_scripts/psutil_monitor.py
@@ -109,7 +109,7 @@ def main():
     ncpu_system = ncpu_affinity
 
     # Print detected resources
-    print(f"CPUs available (affinity): {ncpu_affinity} -> {affinity_cpus}")
+    print(f"CPUs available (affinity): {ncpu_affinity}")
     vm_total = psutil.virtual_memory().total
     print(f"Total memory available: {bytes_human(vm_total)}")
 


### PR DESCRIPTION
## Summary
- derive CPU basis from os.sched_getaffinity and show available CPUs and total memory at startup
- format per-sample output to include provided CPU count and total memory

## Testing
- `python -m py_compile src/hpc_scripts/psutil_monitor.py`
- `python src/hpc_scripts/psutil_monitor.py --mode system --interval 0.1 --duration 0.2`


------
https://chatgpt.com/codex/tasks/task_e_689b3e29c42c832bb3a6d2c92901b6d1