### PR TITLE
Add node allocation info to PBS bulk user stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ feature of `psutil-monitor`.
 
 ### `pbs-bulk-user-stats`
 
-Summarize CPU and memory usage for PBS jobs. The command relies on `qstat`
-being available in your `PATH`.
+Summarize CPU and memory usage for PBS jobs and show which nodes the jobs are
+allocated to. The command relies on `qstat` being available in your `PATH`.
 
 Examples:
 


### PR DESCRIPTION
## Summary
- show nodes allocated to each job in `pbs-bulk-user-stats` output
- document node information in README

## Testing
- `python -m py_compile src/hpc_scripts/pbs_bulk_user_stats.py`
- `python src/hpc_scripts/pbs_bulk_user_stats.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689d9c2f87b0832b99eeae68dc4a3273