### PR TITLE
refactor: clarify memory variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ JOBID    STATE   NAME       NODES    NCPUS  WALL(h)  CPUT(h)  avgCPU  CPUeff  me
 0002      R      run2		pbs-2    176    38.59    3589.72  93.13  52.91%  50.02 GiB 256.00 GiB 19.54%
 ```
 
+After the table, a summary reports the job count, mean CPU efficiency,
+mean average CPU usage, mean memory efficiency, and the peak memory used
+across all listed jobs.
+
 ### `psutil-monitor`
 
 Real-time CPU and memory monitor for the system or a process tree.
@@ -64,8 +68,10 @@ Real-time CPU and memory monitor for the system or a process tree.
 Examples:
 
 ```bash
-# System-wide (by default) monitoring with CSV and PNG output
+# System-wide (by default) monitoring with console output only
 psutil-monitor
+
+# System-wide monitoring with CSV and PNG output
 psutil-monitor --mode system --csv node.csv --plot node.png
 
 # Monitor the current process tree (useful inside a PBS job)


### PR DESCRIPTION
## Summary
- rename memory tracking variables in psutil_monitor for better clarity
- rename memory metrics in pbs_bulk_user_stats to explicit *_bytes names and adjust summary output

## Testing
- `python -m pytest`
- `python src/hpc_scripts/psutil_monitor.py --mode system --interval 0.5 --duration 1`
- `python src/hpc_scripts/psutil_monitor.py --mode system --interval 0.5 --duration 1 --csv sys.csv`
- `python src/hpc_scripts/pbs_bulk_user_stats.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689de44d64bc832b98a5314acb778bdf