### PR TITLE
Default pbs-bulk-user-stats --user to current username

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,18 @@ Examples:
 
 ```bash
 # Summarize a specific job and write CSV output
-pbs-bulk-user-stats --job 12345 --csv stats.csv 
+pbs-bulk-user-stats --job 12345 --csv stats.csv
 
-# Summarize all jobs for a user
+# Summarize all jobs for the current user (default)
+pbs-bulk-user-stats --include-finished
+
+# Summarize all jobs for a specific user
 pbs-bulk-user-stats --user myuser --include-finished
 ```
 
 **Expected output:**
 ```
-$ pbs-bulk-user-stats --user myuser
+$ pbs-bulk-user-stats
 
 JOBID    STATE   NAME       NODES    NCPUS  WALL(h)  CPUT(h)  avgCPU  CPUeff  memUsed   memReq   memEff
 -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- default `--user` argument to the current username using PBS or shell environment
- document new default behavior in README

## Testing
- `python -m py_compile src/hpc_scripts/pbs_bulk_user_stats.py`
- `python src/hpc_scripts/pbs_bulk_user_stats.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ada4efa740832baeb0ddcf57ff12da